### PR TITLE
Bad Markdown heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,6 @@ indent_style = tab
 
 ```
 
-##Contributions
+## Contributions
 
 You are welcome to generates a PR with your favorite guidelines.


### PR DESCRIPTION
Markdown for "Contributions" heading was not rendering correctly, added a missing whitespace